### PR TITLE
AE350: Fix broken SMP support

### DIFF
--- a/target/riscv/cpu_helper.c
+++ b/target/riscv/cpu_helper.c
@@ -85,9 +85,9 @@ uint32_t riscv_cpu_update_mip(RISCVCPU *cpu, uint32_t mask, uint32_t value)
         cmp = atomic_cmpxchg(&env->mip, old, new);
     } while (old != cmp);
 
-    if (new && !old) {
+    if (new) {
         cpu_interrupt(CPU(cpu), CPU_INTERRUPT_HARD);
-    } else if (!new && old) {
+    } else {
         cpu_reset_interrupt(CPU(cpu), CPU_INTERRUPT_HARD);
     }
 


### PR DESCRIPTION
This fixes broken SMP support in the Andes AE350 model.

Verified on booting VxWorks 7 on Andes AE350.